### PR TITLE
Build: Point dependencies to Maven repository instead of Vaadin-Eclipse plugin

### DIFF
--- a/build/build.properties
+++ b/build/build.properties
@@ -1,8 +1,8 @@
 result-path=build/result
 
-gwt.dev.dir=/Applications/eclipse/configuration/com.vaadin.integration.eclipse/download/gwt-dev/2.3.0
-gwt.user.dir=/Applications/eclipse/configuration/com.vaadin.integration.eclipse/download/gwt-user/2.3.0
-gwt.deps.dir=/Applications/eclipse/configuration/com.vaadin.integration.eclipse/download/gwt-dependencies/2.3.0
+gwt.dev.dir=${user.home}/.m2/repository/com/google/gwt/gwt-dev/2.3.0
+gwt.user.dir=${user.home}/.m2/repository/com/google/gwt/gwt-user/2.3.0
+gwt.deps.dir=${user.home}/.m2/repository/javax/validation/validation-api/1.0.0.GA
 
 src.package.dir=org/tepi/filtertable
 src.customtable.dir=com/vaadin/ui


### PR DESCRIPTION
This is a bit more debatable, but I'll argue that it's more portable than the previous configuration.
