### PR TITLE
Update FilterFieldGenerator.java

### DIFF
--- a/src/org/tepi/filtertable/FilterFieldGenerator.java
+++ b/src/org/tepi/filtertable/FilterFieldGenerator.java
@@ -81,7 +81,7 @@ class FilterFieldGenerator implements Serializable {
 							.getContainerDataSource().getType(property));
 					addFilterColumn(property, filter);
 				} else {
-					addFilterColumn(property, createField(null, null));
+					addFilterColumn(property, createField(property, null));
 				}
 			}
 		}


### PR DESCRIPTION
In some cases I need to know name of property to create proper filtering field otherwise I am not able to create it for this specific property which isn't listed as container property id  - getContainerPropertyIds (for example: column generated based on some other properties - see colum status in the picture)
![example](https://f.cloud.github.com/assets/160366/1158369/6fa72b38-1fb3-11e3-8282-a4d03b66b76d.jpg)
