### PR TITLE
FilterTable should override #setContainerDataSource(Container,Collection)

### DIFF
--- a/src/org/tepi/filtertable/FilterTable.java
+++ b/src/org/tepi/filtertable/FilterTable.java
@@ -1,5 +1,6 @@
 package org.tepi.filtertable;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -123,6 +124,13 @@ public class FilterTable extends CustomTable implements IFilterTable {
     @Override
     public void setContainerDataSource(Container newDataSource) {
         super.setContainerDataSource(newDataSource);
+        resetFilters();
+    }
+    
+    @Override
+    public void setContainerDataSource(Container newDataSource,
+            Collection<?> visibleIds) {
+        super.setContainerDataSource(newDataSource, visibleIds);
         resetFilters();
     }
 


### PR DESCRIPTION
As per documentation of CustomTable#setContainerDataSource(Container,Collection), this method
should be called whenever only a subset of the columns shall be displayed, instead of the usual
CustomTable#setContainerDataSource(Collection). Thus, FilterTable should override it as well.
