### PR TITLE
Optimize conent refreshing

### DIFF
--- a/src/com/vaadin/ui/CustomTable.java
+++ b/src/com/vaadin/ui/CustomTable.java
@@ -2779,7 +2779,7 @@ public class CustomTable extends AbstractSelect implements Action.Container,
         // Assure visual refresh
         resetPageBuffer();
 
-        enableContentRefreshing(true);
+        enableContentRefreshing(false);
     }
 
     /**

--- a/src/org/tepi/filtertable/FilterTable.java
+++ b/src/org/tepi/filtertable/FilterTable.java
@@ -137,7 +137,6 @@ public class FilterTable extends CustomTable implements IFilterTable {
     @Override
     public void setContainerDataSource(Container newDataSource) {
         super.setContainerDataSource(newDataSource);
-        resetFilters();
     }
 
     @Override

--- a/src/org/tepi/filtertable/FilterTreeTable.java
+++ b/src/org/tepi/filtertable/FilterTreeTable.java
@@ -116,7 +116,6 @@ public class FilterTreeTable extends CustomTreeTable implements IFilterTable {
     @Override
     public void setContainerDataSource(Container newDataSource) {
         super.setContainerDataSource(newDataSource);
-        resetFilters();
     }
 
     @Override


### PR DESCRIPTION
If FilteringTable is used with lazy query container, setContainerDataSource(Container) causes three times loading of data from the persistence backend. These two commits reduce it to one in resetFilters().