### PR TITLE
Open DateFilterPopup for subclassing

### DIFF
--- a/src/org/tepi/filtertable/datefilter/DateFilterPopup.java
+++ b/src/org/tepi/filtertable/datefilter/DateFilterPopup.java
@@ -34,13 +34,13 @@ import com.vaadin.ui.VerticalLayout;
  */
 @SuppressWarnings("serial")
 public class DateFilterPopup extends CustomField<DateInterval> {
-    private PopupButton content;
+    protected PopupButton content;
 
-    private DateField fromField, toField;
+    protected DateField fromField, toField;
     private Date fromValue, toValue;
     private boolean cancelReset;
     private FilterDecorator decorator;
-    private Button set, clear;
+    protected Button set, clear;
     private final Object propertyId;
     private String dateFormatPattern;
 
@@ -76,7 +76,7 @@ public class DateFilterPopup extends CustomField<DateInterval> {
         updateCaption(newFieldValue.isNull());
     }
 
-    private void buildPopup() {
+    protected void buildPopup() {
         VerticalLayout content = new VerticalLayout();
         content.setStyleName("datefilterpopupcontent");
         content.setSpacing(true);
@@ -114,7 +114,7 @@ public class DateFilterPopup extends CustomField<DateInterval> {
         content.addComponent(row);
         content.addComponent(buttonBar);
         content.setComponentAlignment(buttonBar, Alignment.BOTTOM_RIGHT);
-
+        
         this.content.setContent(content);
     }
 
@@ -284,4 +284,5 @@ public class DateFilterPopup extends CustomField<DateInterval> {
         fromField.setEnabled(!readOnly);
         toField.setEnabled(!readOnly);
     }
+    
 }


### PR DESCRIPTION
Hi,
I really like your DateFilterPopup. We use it also in other cases beside the FilterTable. 

However, DateFilterPopup is not opened for subclassing. It would be nice if we can hook into the building of the popup and access the components to add additional functionality.
Our concrete use cases: We like to change the value of the toField if the fromField has been changed. Therefore, we need to add a ValueChangeListener to the fromField in the subclass.

To achieve this (and similar use cases) I suppose to change the visibility of the DateFields, Buttons, the PopupButton and the method buildPopup() to protected. This way subclasses can overwrite buildPopup() and add additional logic using the components.

Best Regards
Philipp